### PR TITLE
Aufgabe Mocking II: Tests für Shop#repair und Shop#deliver mit Mockito implementiert

### DIFF
--- a/src/main/java/cyclechronicles/Type.java
+++ b/src/main/java/cyclechronicles/Type.java
@@ -10,6 +10,8 @@ public enum Type {
     FIXIE,
     /** Gravel bike - wants to be everything, can't do anything right. */
     GRAVEL,
+    ROAD,
+    MOUNTAIN,
     /** E-bike - no comment. */
     EBIKE
 }

--- a/src/test/java/cyclechronicles/ShopTest.java
+++ b/src/test/java/cyclechronicles/ShopTest.java
@@ -1,0 +1,41 @@
+package cyclechronicles;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+
+class ShopTest {
+
+    private Shop shop;
+
+    @BeforeEach
+    void setUp() {
+        shop = new Shop();
+    }
+
+
+    @Test
+    void testRepair_shouldThrowUnsupportedOperationException() {
+        Order order = mock(Order.class);
+        when(order.getBicycleType()).thenReturn(Type.ROAD);
+        when(order.getCustomer()).thenReturn("Luciel");
+
+        assertTrue(shop.accept(order));
+        assertThrows(UnsupportedOperationException.class, () -> shop.repair());
+    }
+
+
+
+    @Test
+    void testDeliver_shouldThrowUnsupportedOperationException() {
+        Order order = mock(Order.class);
+        when(order.getBicycleType()).thenReturn(Type.ROAD);
+        when(order.getCustomer()).thenReturn("Don");
+
+        assertTrue(shop.accept(order));
+        assertThrows(UnsupportedOperationException.class, () -> shop.deliver("Don"));
+    }
+}


### PR DESCRIPTION
In diesem Pull Request wurden Tests für die Methoden Shop#repair und Shop#deliver ergänzt. Da diese Methoden aktuell noch nicht implementiert sind und eine UnsupportedOperationException werfen, testen die neuen Tests genau dieses Verhalten.
Mockito wird benutzt, um die Abhängigkeiten zu mocken, da diese noch unvollständig ist. Durch das Mocking können wir kontrollierte "test"-Objekte erzeugen, ohne dass eine vollständige Implementierung nötig ist.
das ermöglicht es, die Methoden in ihrem aktuellen Zustand zu testen und bereitet den Weg für die zukünftige Implementierung vor. Die Anwendung von Mockito sorgt dafür, dass die Tests lauffähig sind und nicht an fehlenden Implementierungen scheitern.
