### PR TITLE
Aufgabe Record Klassen : Order als Record implementiert und Shop s angepasst

### DIFF
--- a/src/main/java/cyclechronicles/Order.java
+++ b/src/main/java/cyclechronicles/Order.java
@@ -1,22 +1,5 @@
 package cyclechronicles;
 
-/** An order for a bike shop. */
-public class Order {
-    /**
-     * Determine the type of bike to be repaired.
-     *
-     * @return type of bicycle
-     */
-    public Type getBicycleType() {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
-     * Determine the customer who placed this order.
-     *
-     * @return name of customer
-     */
-    public String getCustomer() {
-        throw new UnsupportedOperationException();
-    }
+public record Order(Type bicycleType, String customer) {
+ 
 }

--- a/src/main/java/cyclechronicles/Order.java
+++ b/src/main/java/cyclechronicles/Order.java
@@ -1,5 +1,5 @@
 package cyclechronicles;
 
 public record Order(Type bicycleType, String customer) {
- 
+
 }

--- a/src/main/java/cyclechronicles/Shop.java
+++ b/src/main/java/cyclechronicles/Shop.java
@@ -26,9 +26,9 @@ public class Shop {
      *     otherwise
      */
     public boolean accept(Order o) {
-        if (o.getBicycleType() == Type.GRAVEL) return false;
-        if (o.getBicycleType() == Type.EBIKE) return false;
-        if (pendingOrders.stream().anyMatch(x -> x.getCustomer().equals(o.getCustomer())))
+        if (o.bicycleType() == Type.GRAVEL) return false;
+        if (o.bicycleType() == Type.EBIKE) return false;
+        if (pendingOrders.stream().anyMatch(x -> x.customer().equals(o.customer())))
             return false;
         if (pendingOrders.size() > 4) return false;
 


### PR DESCRIPTION
Die Klasse Order wurde von einer  normalen Klasse zu einer Record-Klasse umgebaut, um die beiden Attribute `bicycleType` und `customer` klar und kompakt darzustellen.
Dadurch entfallen die bisher verwendeten Getter-Methoden `getBicycleType()` und `getCustomer()`. Stattdessen werden jetzt die automatisch erzeugten Methoden `bicycleType()` und `customer()` verwendet.
Alle Aufrufe in der Klasse Shop sowie in den JUnit-Tests wurden entsprechend angepasst.

